### PR TITLE
Use https URLs in .version file

### DIFF
--- a/X-Science/GameData/[x] Science!/[x] Science!.version
+++ b/X-Science/GameData/[x] Science!/[x] Science!.version
@@ -1,8 +1,8 @@
 {
     "NAME":"[x] Science!",
-    "URL":"http://themoose.co.uk/ksp/%5Bx%5D%20Science!.version",
-    "DOWNLOAD":"http://themoose.co.uk/ksp/downloads.html",
-    "CHANGE_LOG_URL":"http://themoose.co.uk/ksp/CHANGES.md"
+    "URL":"https://themoose.co.uk/ksp/%5Bx%5D%20Science!.version",
+    "DOWNLOAD":"https://themoose.co.uk/ksp/downloads.html",
+    "CHANGE_LOG_URL":"https://themoose.co.uk/ksp/CHANGES.md"
     "VERSION":
     {
         "MAJOR":4,


### PR DESCRIPTION
Since https://themoose.co.uk/ksp/downloads.html works fine, it seems better to default to downloading software over https.