### PR TITLE
Add configuration setting to only stop time warp when new biome has b…

### DIFF
--- a/X-Science/Config.cs
+++ b/X-Science/Config.cs
@@ -19,6 +19,7 @@ namespace ScienceChecklist {
 			private bool _checkDebris;
 			private bool _allFilter;
 			private bool _stopTimeWarp;
+			private bool _stopTimeWarpOnlyOnNewScience;
 			private bool _playNoise;
 			private bool _showResultsWindow;
 
@@ -31,6 +32,7 @@ namespace ScienceChecklist {
 			public bool CheckDebris						{ get { return _checkDebris; }					set { if( _checkDebris != value ) { _checkDebris = value; OnCheckDebrisChanged( ); } } }
 			public bool AllFilter						{ get { return _allFilter; }					set { if( _allFilter != value ) { _allFilter = value; OnAllFilterChanged( ); } } }
 			public bool StopTimeWarp					{ get { return _stopTimeWarp; }					set { if( _stopTimeWarp != value ) { _stopTimeWarp = value; OnStopTimeWarpChanged( ); } } }
+			public bool StopTimeWarpOnlyOnNewScience	{ get { return _stopTimeWarpOnlyOnNewScience; }	set { if( _stopTimeWarpOnlyOnNewScience != value ) { _stopTimeWarpOnlyOnNewScience = value; OnStopTimeWarpOnlyOnNewScienceChanged( ); } } }
 			public bool PlayNoise						{ get { return _playNoise; }					set { if( _playNoise != value ) { _allFilter = value; OnPlayNoiseChanged( ); } } }
 			public bool ShowResultsWindow				{ get { return _showResultsWindow; }			set { if( _showResultsWindow != value ) { _showResultsWindow = value; OnShowResultsWindowChanged( ); } } }
 
@@ -43,6 +45,7 @@ namespace ScienceChecklist {
 			public event EventHandler CheckDebrisChanged;
 			public event EventHandler AllFilterChanged;
 			public event EventHandler StopTimeWarpChanged;
+			public event EventHandler StopTimeWarpOnlyOnNewScienceChanged;
 			public event EventHandler PlayNoiseChanged;
 			public event EventHandler ShowResultsWindowChanged;
 
@@ -97,7 +100,15 @@ namespace ScienceChecklist {
 				}
 			}
 
-			private void OnPlayNoiseChanged( )
+			private void OnStopTimeWarpOnlyOnNewScienceChanged()
+			{
+				if (StopTimeWarpOnlyOnNewScienceChanged != null)
+				{
+					StopTimeWarpOnlyOnNewScienceChanged(this, EventArgs.Empty);
+				}
+			}
+
+		private void OnPlayNoiseChanged( )
 			{
 				if( PlayNoiseChanged != null )
 				{
@@ -187,6 +198,7 @@ namespace ScienceChecklist {
 			settings.AddValue( "CheckDebris",					_checkDebris );
 			settings.AddValue( "AllFilter",						_allFilter );
 			settings.AddValue( "StopTimeWarp",					_stopTimeWarp );
+			settings.AddValue( "StopTimeWarpOnlyOnNewScience",	_stopTimeWarpOnlyOnNewScience );
 			settings.AddValue( "PlayNoise",						_playNoise );
 			settings.AddValue( "ShowResultsWindow",				_showResultsWindow );
 
@@ -225,6 +237,7 @@ namespace ScienceChecklist {
 			_checkDebris =					false;
 			_allFilter =					true;
 			_stopTimeWarp =					true;
+			_stopTimeWarpOnlyOnNewScience = false;
 			_playNoise =					true;
 			_showResultsWindow =			true;
 
@@ -266,6 +279,10 @@ namespace ScienceChecklist {
 					V = settings.GetValue( "StopTimeWarp" );
 					if( V != null )
 						_stopTimeWarp = bool.Parse( V );
+
+					V = settings.GetValue( "StopTimeWarpOnlyOnNewScience" );
+					if ( V != null )
+						_stopTimeWarpOnlyOnNewScience = bool.Parse( V );
 
 					V = settings.GetValue( "PlayNoise" );
 					if( V != null )

--- a/X-Science/ExperimentFilter.cs
+++ b/X-Science/ExperimentFilter.cs
@@ -25,7 +25,7 @@ namespace ScienceChecklist {
 			_displayMode = DisplayMode.Unlocked;
 			_text = string.Empty;
 			DisplayScienceInstances = new List<ScienceInstance>( );
-			CompleteCount = TotalCount = 0;
+			CompleteCount = TotalCount = NewScienceCount = 0;
 			EnforceLabLanderMode = false;
 			TotalScience = CompletedScience = OutstandingScience = 0;
 		}
@@ -44,6 +44,7 @@ namespace ScienceChecklist {
 		/// Gets the total number of display experiments.
 		/// </summary>
 		public int              TotalCount         { get; private set; }
+		public int				NewScienceCount			{ get; private set; }
 
 		public float TotalScience { get; private set; }
 		public float CompletedScience { get; private set; }
@@ -176,6 +177,8 @@ namespace ScienceChecklist {
 				TotalScience = RemainingExperiments.Sum( x => x.TotalScience );
 				CompletedScience = RemainingExperiments.Sum( x => x.CompletedScience );
 			}
+
+			NewScienceCount = query.Count(x => (x.CompletedScience + x.OnboardScience) < 0.1);
 
 
 

--- a/X-Science/GameData/[x] Science!/PluginData/[x] Science!/settings.cfg
+++ b/X-Science/GameData/[x] Science!/PluginData/[x] Science!/settings.cfg
@@ -8,6 +8,7 @@ ScienceChecklist
 		CheckDebris = False
 		AllFilter = True
 		StopTimeWarp = True
+		StopTimeWarpOnlyOnNewScience = False
 		PlayNoise = True
 		ShowResultsWindow = True
 	}

--- a/X-Science/StatusWindow.cs
+++ b/X-Science/StatusWindow.cs
@@ -280,7 +280,7 @@ namespace ScienceChecklist
 				{
 					if( IsVisible( ) )
 					{
-						if( _parent.Config.StopTimeWarp )
+						if( _parent.Config.StopTimeWarp && ( !_parent.Config.StopTimeWarpOnlyOnNewScience || _filter.NewScienceCount > 0 ))
 							GameHelper.StopTimeWarp( );
 						if( _parent.Config.PlayNoise )
 							PlayNoise( );


### PR DESCRIPTION
…rand new science

This makes it much easier to quickly orbit a planet looking for new science, because your warp won't stop when entering a biome that you've already collected (either at KSC or on vessel) science for before.